### PR TITLE
Added annotation scanning for newer spring annotations

### DIFF
--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -1,19 +1,5 @@
 package com.coveo.feign;
 
-import com.coveo.feign.hierarchy.ClassHierarchySupplier;
-import com.coveo.feign.hierarchy.EmptyClassHierarchySupplier;
-import com.coveo.feign.hierarchy.SpringClassHierarchySupplier;
-import com.coveo.feign.util.ClassUtils;
-import feign.RequestLine;
-import feign.Response;
-import feign.Util;
-import feign.codec.Decoder;
-import feign.codec.ErrorDecoder;
-import feign.jackson.JacksonDecoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.RequestMapping;
-
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -27,6 +13,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.coveo.feign.hierarchy.ClassHierarchySupplier;
+import com.coveo.feign.hierarchy.EmptyClassHierarchySupplier;
+import com.coveo.feign.hierarchy.SpringClassHierarchySupplier;
+import com.coveo.feign.util.ClassUtils;
+
+import feign.RequestLine;
+import feign.Response;
+import feign.Util;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+import feign.jackson.JacksonDecoder;
 
 @SuppressWarnings("unchecked")
 public abstract class ReflectionErrorDecoder<T, S extends Exception> implements ErrorDecoder {

--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -82,9 +82,10 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
 
       for (Method method : apiClass.getMethods()) {
         if (method.getAnnotation(RequestLine.class) != null
-            || (isSpringWebAvailable && method.getAnnotation(RequestMapping.class) != null)
-            || Stream.of(method.getAnnotations())
-                .anyMatch(a -> a.annotationType().getAnnotation(RequestMapping.class) != null)) {
+            || (isSpringWebAvailable
+                && Stream.of(method.getAnnotations())
+                    .anyMatch(
+                        a -> a.annotationType().getAnnotation(RequestMapping.class) != null))) {
           processDeclaredThrownExceptions(method.getExceptionTypes(), baseExceptionClass);
         }
       }

--- a/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
+++ b/src/main/java/com/coveo/feign/ReflectionErrorDecoder.java
@@ -1,5 +1,19 @@
 package com.coveo.feign;
 
+import com.coveo.feign.hierarchy.ClassHierarchySupplier;
+import com.coveo.feign.hierarchy.EmptyClassHierarchySupplier;
+import com.coveo.feign.hierarchy.SpringClassHierarchySupplier;
+import com.coveo.feign.util.ClassUtils;
+import feign.RequestLine;
+import feign.Response;
+import feign.Util;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+import feign.jackson.JacksonDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -12,22 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.RequestMapping;
-
-import com.coveo.feign.hierarchy.ClassHierarchySupplier;
-import com.coveo.feign.hierarchy.EmptyClassHierarchySupplier;
-import com.coveo.feign.hierarchy.SpringClassHierarchySupplier;
-import com.coveo.feign.util.ClassUtils;
-
-import feign.RequestLine;
-import feign.Response;
-import feign.Util;
-import feign.codec.Decoder;
-import feign.codec.ErrorDecoder;
-import feign.jackson.JacksonDecoder;
+import java.util.stream.Stream;
 
 @SuppressWarnings("unchecked")
 public abstract class ReflectionErrorDecoder<T, S extends Exception> implements ErrorDecoder {
@@ -83,7 +82,9 @@ public abstract class ReflectionErrorDecoder<T, S extends Exception> implements 
 
       for (Method method : apiClass.getMethods()) {
         if (method.getAnnotation(RequestLine.class) != null
-            || (isSpringWebAvailable && method.getAnnotation(RequestMapping.class) != null)) {
+            || (isSpringWebAvailable && method.getAnnotation(RequestMapping.class) != null)
+            || Stream.of(method.getAnnotations())
+                .anyMatch(a -> a.annotationType().getAnnotation(RequestMapping.class) != null)) {
           processDeclaredThrownExceptions(method.getExceptionTypes(), baseExceptionClass);
         }
       }

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -1,10 +1,17 @@
 package com.coveo.feign;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.RequestLine;
-import feign.Response;
-import feign.codec.ErrorDecoder;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -14,20 +21,12 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.lang.reflect.Field;
-import java.nio.charset.Charset;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
+import feign.RequestLine;
+import feign.Response;
+import feign.codec.ErrorDecoder;
 
 @SuppressWarnings({"resource", "unused"})
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
+++ b/src/test/java/com/coveo/feign/ReflectionErrorDecoderTest.java
@@ -1,9 +1,18 @@
 package com.coveo.feign;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.RequestLine;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
@@ -12,19 +21,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import feign.RequestLine;
-import feign.Response;
-import feign.codec.ErrorDecoder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
 
 @SuppressWarnings({"resource", "unused"})
 @RunWith(MockitoJUnitRunner.class)
@@ -247,6 +250,14 @@ public class ReflectionErrorDecoderTest {
     @RequestLine("")
     void anotherMethodWithStringAndThrowableConstructorException()
         throws ExceptionWithStringAndThrowableConstructorException;
+
+    @RequestMapping("")
+    void methodWithRequestMappingAndStringConstructorException()
+        throws ExceptionWithStringConstructorException;
+
+    @GetMapping("")
+    void methodWithGetMappingAndStringConstructorException()
+        throws ExceptionWithStringConstructorException;
   }
 
   private static interface TestApiClassWithInheritedExceptions {


### PR DESCRIPTION
With this change you can use the newer type of annotations introduced in spring 4.3 (e.g. @PostMapping)